### PR TITLE
Updated gradle file so jackson doesn't break the build

### DIFF
--- a/App/app/build.gradle
+++ b/App/app/build.gradle
@@ -18,6 +18,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    packagingOptions {
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/DEPENDENCIES'
+    }
 }
 
 dependencies {
@@ -31,7 +36,7 @@ dependencies {
     compile 'com.android.support:support-vector-drawable:23.4.0'
     testCompile 'junit:junit:4.12'
     compile 'com.google.code.gson:gson:2.2.4'
-    
+
     compile 'com.fasterxml.jackson.core:jackson-core:2.7.3'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.3'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'


### PR DESCRIPTION
Based on SO post here: http://stackoverflow.com/questions/35909785/android-studio-trouble-setting-up-jackson-parser-on-gradle and http://stackoverflow.com/questions/26352958/duplicate-files-when-adding-compiling-with-gradle-in-android-studio
