### PR TITLE
Fixed and updated Login/Signup:

### DIFF
--- a/App/app/src/main/java/northseattlecollege/ASLBuddy/LoginActivity.java
+++ b/App/app/src/main/java/northseattlecollege/ASLBuddy/LoginActivity.java
@@ -73,7 +73,7 @@ public class LoginActivity extends AppCompatActivity implements LoaderCallbacks<
      * TODO: remove after connecting to a real authentication system.
      */
     private static final String[] DUMMY_CREDENTIALS = new String[]{
-            "interpreter@example.com:interpreter", "hoh@example.com:hoh"
+            "interpreter@example.com:password", "hoh@example.com:password"
     };
 
     // Variables for user login

--- a/App/app/src/main/res/values/strings.xml
+++ b/App/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="error_invalid_email">This email address is invalid</string>
     <string name="error_invalid_password">This password is too short</string>
     <string name="error_incorrect_password">This password is incorrect</string>
+    <string name="error_failed_login">Couldn\'t sign in with email and/or password</string>
     <string name="error_field_required">This field is required</string>
     <string name="permission_rationale">"Contacts permissions are needed for providing email
         completions."


### PR DESCRIPTION
Fixed the bug where redirection was always to HOH menu unless creating new account, added Javadoc comments, and added another custom error when server login fails.

Additionally, added the dummy credentials logic back in as a failsafe for server authentication.  Basically, it tries to login checking against the server, and if that fails It will check if you're using the dummy credentials and log in that way.

New Dummy Credentials:
interpreter@example.com
pass: "password"
hoh@example.com
pass: "password"

@timdavish @nlflint @jesse-bernoudy @BobMcHenry @cdriggin @austin-a @GrantZukowski 